### PR TITLE
Extract ServiceNameFactory

### DIFF
--- a/cdif.h
+++ b/cdif.h
@@ -5,9 +5,11 @@ namespace cdif {
     class Registrar;
     class Registration;
     class IModule;
+    class ServiceNameFactory;
 };
 
 #include "registration.h"
 #include "registrar.h"
 #include "imodule.h"
+#include "servicenamefactory.h"
 #include "container.h"

--- a/servicenamefactory.h
+++ b/servicenamefactory.h
@@ -1,0 +1,16 @@
+#include <string>
+
+namespace cdif {
+    class ServiceNameFactory {
+        public:
+            template <typename TService>
+            const std::string Create(const std::string & name) const {
+                auto typeName = typeid(TService).name();
+                if (!name.empty())
+                    return typeName + name;
+
+                return typeName;
+            }
+    };
+};
+


### PR DESCRIPTION
Leave the details of name generation up to a standalone factory rather
than pawning off that responsibility to the `Container`