### PR TITLE
Allow move-only type registration

### DIFF
--- a/registration.h
+++ b/registration.h
@@ -2,6 +2,7 @@
 
 #include <any>
 #include <functional>
+#include <type_traits>
 
 #include "cdif.h"
 
@@ -11,8 +12,15 @@ namespace cdif {
             std::function<std::any(const cdif::Container &)> m_resolver;
 
         public:
-            Registration(std::function<std::any (const cdif::Container&)> resolver)
+            Registration(std::function<std::any (const cdif::Container &)> resolver)
                 : m_resolver(resolver) {};
+
+            template <typename T>
+            Registration(std::function<T (const cdif::Container &)> resolver)
+                requires !std::is_copy_constructible<T>::value && std::is_move_constructible<T>::value
+            {
+                m_resolver = [resolver] (const cdif::Container &) { return resolver; };
+            }
 
             virtual ~Registration() = default;
 
@@ -25,6 +33,14 @@ namespace cdif {
             template <typename T>
             T Resolve(const cdif::Container & ctx) const {
                 return std::any_cast<T>(m_resolver(ctx));
+            }
+
+            template <typename T>
+            T Resolve(const cdif::Container & ctx) const
+                requires !std::is_copy_constructible<T>::value && std::is_move_constructible<T>::value
+            {
+                auto resolver = std::any_cast<std::function<T (const cdif::Container &)>>(m_resolver(ctx));
+                return std::move(resolver(ctx));
             }
     };
 }

--- a/servicenamefactory.h
+++ b/servicenamefactory.h
@@ -6,10 +6,7 @@ namespace cdif {
             template <typename TService>
             const std::string Create(const std::string & name) const {
                 auto typeName = typeid(TService).name();
-                if (!name.empty())
-                    return typeName + name;
-
-                return typeName;
+                return typeName + name;
             }
     };
 }

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,5 +1,5 @@
 GCC ?= g++
-CXX_FLAGS += --std=c++17 -I../ -I./mocks -Wall -Wextra -Wshadow -Wnon-virtual-dtor -Wold-style-cast -Wcast-align -Wunused -Woverloaded-virtual -pedantic -Wconversion -Wsign-conversion -Wmisleading-indentation
+CXX_FLAGS += --std=c++17 -fconcepts -I../ -I./mocks -Wall -Wextra -Wshadow -Wnon-virtual-dtor -Wold-style-cast -Wcast-align -Wunused -Woverloaded-virtual -pedantic -Wconversion -Wsign-conversion -Wmisleading-indentation
 LIBS = -lgtest_main -lgtest -lpthread
 
 OBJDIR = ./obj


### PR DESCRIPTION
move-only types can now be registered. This also forces use of concepts
`-fconcepts`.

Additionally the `cdif::Container::Register` function has changed and
expanded. Calling `container.Register<TService, TImpl, TDeps...>` now
results in three unique registrations: `std::shared_ptr<TService>`,
`std::unique_ptr<TService>`, and `TImpl` all of which can be used as the
type argument to `container.Resolve<T>`. Additionally, if a `name`
argument is specified when calling `Register` any of the three
registered types can be resolved using the same name.