### PR TITLE
Fix Inability to Resolve Non-Copyable Dependency

### DIFF
--- a/builders/interfaceregistrationbuilder.h
+++ b/builders/interfaceregistrationbuilder.h
@@ -12,7 +12,7 @@ namespace cdif {
     class InterfaceRegistrationBuilder : public RegistrationBuilder<TScope, TService, TCtorArgs...>
     {
         private:
-            typedef std::array<std::function<std::any (const Container&)>, sizeof...(TCtorArgs)> ResolverCollection;
+            typedef std::array<std::function<std::any ()>, sizeof...(TCtorArgs)> ResolverCollection;
 
             template <typename TRet, typename Indices = std::make_index_sequence<sizeof...(TCtorArgs)>>
             void buildRegistrationFrom(

--- a/builders/typeregistrationbuilder.h
+++ b/builders/typeregistrationbuilder.h
@@ -12,7 +12,7 @@ namespace cdif {
     class TypeRegistrationBuilder : public RegistrationBuilder<TScope, TService, TCtorArgs...>
     {
         private:
-            typedef std::array<std::function<std::any (const Container&)>, sizeof...(TCtorArgs)> ResolverCollection;
+            typedef std::array<std::function<std::any ()>, sizeof...(TCtorArgs)> ResolverCollection;
 
             template <typename TRet, typename Indices = std::make_index_sequence<sizeof...(TCtorArgs)>>
             void buildRegistrationFrom(

--- a/tests/container_tests.cc
+++ b/tests/container_tests.cc
@@ -375,3 +375,14 @@ TEST_F(ContainerTests, Resolve_GivenPerThreadRegistration_ResolvesSingleInstance
     auto t = std::thread(functor);
     t.join();
 }
+
+TEST_F(ContainerTests, Resolve_GivenTypeWithDependencyOnNonCopyableType_CanResolveContainer)
+{
+    givenRegistrationReturningValue(342);
+    _subject.bind<SimpleImplementation, int>().as<Interface>().build();
+    _subject.bind<UniqueImplementationDecorator, int, std::unique_ptr<Interface>>().build();
+
+    auto result = _subject.resolve<UniqueImplementationDecorator>();
+
+    ASSERT_NE(&result, nullptr);
+}

--- a/type_traits.h
+++ b/type_traits.h
@@ -127,9 +127,9 @@ namespace cdif
 
     template <typename TDep, size_t Index, size_t FuncCount>
     static const std::function<TDep (const Container&)> getResolverAtIndex(
-        const std::array<std::function<std::any (const cdif::Container&)>, FuncCount>& resolvers)
+        const std::array<std::function<std::any ()>, FuncCount>& resolvers)
     {
-        auto func = resolvers[Index];
-        return [func] (const cdif::Container& ctx) { return std::any_cast<TDep>(func(ctx)); };
+        auto func = resolvers[Index]();
+        return std::any_cast<std::function<TDep (const Container&)>>(func);
     }
 }


### PR DESCRIPTION
The previous revision introduced a bug by which you could no longer
resolve a type which had a dependency on a non-copyable (move-only)
type.