### PR TITLE
Fix Factory Registrations

### DIFF
--- a/container.h
+++ b/container.h
@@ -83,7 +83,7 @@ namespace cdif {
             {
                 static_assert(std::is_base_of_v<IModule, TModule>, "TModule must derive IModule");
                 auto module = TModule();
-                static_cast<IModule*>(&module)->load(*this);
+                module.load(*this);
             }
 
             template <typename TService>

--- a/scopedtypefactories.h
+++ b/scopedtypefactories.h
@@ -22,11 +22,33 @@ namespace cdif
 
         template <
             typename T,
+            typename ... TArgs,
+            typename TBase = typename get_base_type<T>::type,
+            typename TFactory = std::function<TBase (TArgs...)>>
+        TBase& createSingletonFactory(const TFactory& factory, TArgs&&... args)
+        {
+            static TBase instance = factory(std::forward<TArgs>(args)...);
+            return instance;
+        }
+
+        template <
+            typename T,
             typename TBase = typename get_base_type<T>::type,
             typename TFactory = std::function<TBase (const Container&)>>
         TBase& createThreadLocal(const TFactory& factory, const Container& ctx) 
         {
             thread_local TBase instance = factory(ctx);
+            return instance;
+        }
+
+        template <
+            typename T,
+            typename ... TArgs,
+            typename TBase = typename get_base_type<T>::type,
+            typename TFactory = std::function<TBase (TArgs...)>>
+        TBase& createThreadLocalFactory(const TFactory& factory, TArgs&&... args)
+        {
+            thread_local TBase instance = factory(std::forward<TArgs>(args)...);
             return instance;
         }
 
@@ -39,6 +61,25 @@ namespace cdif
             static_assert(is_singleton_type<T>,
                 "Requested type is not compatible with scope (must be one of T*, T&, T&&, std::shared_ptr<T>)");
             auto& instance = scopedFactory(factory, ctx);
+
+            if constexpr (std::is_pointer_v<T>)
+                return &instance;
+            else if constexpr (cdif::is_shared_ptr<T>)
+                return std::shared_ptr<TBase>(&instance, [] (auto*) {});
+            else
+                return instance;
+        }
+
+        template <typename T,
+            typename ... TArgs,
+            typename TBase = typename get_base_type<T>::type,
+            typename TFactory = std::function<TBase (TArgs...)>,
+            typename TScopedFactory = std::function<TBase& (const TFactory&, TArgs...)>>
+        T createScopedFactory(const TFactory& factory, const TScopedFactory& scopedFactory, TArgs&&... args)
+        {
+            static_assert(is_singleton_type<T>,
+                "Requested type is not compatible with scope (must be one of T*, T&, T&&, std::shared_ptr<T>)");
+            auto& instance = scopedFactory(factory, std::forward<TArgs>(args)...);
 
             if constexpr (std::is_pointer_v<T>)
                 return &instance;
@@ -63,5 +104,23 @@ namespace cdif
     T createThreadLocal(const TFactory& factory, const Container& ctx)
     {
         return detail::createScoped<T>(factory, ctx, detail::createThreadLocal<T>);
+    }
+
+    template <typename T,
+        typename ... TArgs,
+        typename TBase = typename get_base_type<T>::type,
+        typename TFactory = std::function<TBase (TArgs...)>>
+    T createSingletonFactory(const TFactory& factory, TArgs&&... args)
+    {
+        return detail::createScopedFactory<T>(factory, detail::createSingletonFactory<T, TArgs...>, std::forward<TArgs>(args)...);
+    }
+
+    template <typename T,
+        typename ... TArgs,
+        typename TBase = typename get_base_type<T>::type,
+        typename TFactory = std::function<TBase (TArgs...)>>
+    T createThreadLocalFactory(const TFactory& factory, TArgs&&... args)
+    {
+        return detail::createScopedFactory<T>(factory, detail::createThreadLocalFactory<T, TArgs...>, std::forward<TArgs>(args)...);
     }
 }


### PR DESCRIPTION
Previously scoped factory registrations were broken due to misspelled
usage of a instance variable. This was fixed.

Further work was done to rework how scoped factory registrations
operate. Previously the factory function itself was scoped rather than
the return type of the factory funtion. This was a less that useful
implementation, and was changed to make the return type of the factory
the scoped object.