### PR TITLE
Fix Warnings

### DIFF
--- a/container.h
+++ b/container.h
@@ -4,8 +4,8 @@
 #include <memory>
 #include <stdexcept>
 #include <string>
-#include <typeinfo>
 #include <type_traits>
+#include <typeinfo>
 
 #include "cdif.h"
 
@@ -35,9 +35,9 @@ namespace cdif {
 
        public:
             Container() :
-                    m_registrar(std::move(std::make_unique<cdif::Registrar>())), 
-                    m_serviceNameFactory(std::move(std::make_unique<cdif::ServiceNameFactory>())),
-                    m_dependencyChain(std::move(std::make_unique<cdif::PerThreadDependencyChainTracker>()))
+                    m_registrar(std::make_unique<cdif::Registrar>()),
+                    m_serviceNameFactory(std::make_unique<cdif::ServiceNameFactory>()),
+                    m_dependencyChain(std::make_unique<cdif::PerThreadDependencyChainTracker>())
                     {};
 
             virtual ~Container() = default;

--- a/dependencychaintracker.h
+++ b/dependencychaintracker.h
@@ -67,7 +67,7 @@ namespace cdif {
             void createChain(size_t id)
             {
                 std::unique_lock<std::shared_mutex> writeLock(m_mutex);
-                m_threadChains.insert_or_assign(id, std::move(std::make_unique<DependencyChainTracker>()));
+                m_threadChains.insert_or_assign(id, std::make_unique<DependencyChainTracker>());
             }
 
         public:

--- a/tests/container_tests.cc
+++ b/tests/container_tests.cc
@@ -57,7 +57,7 @@ TEST_F(ContainerTests, Resolve_GivenCircularDependency_ThrowsException)
 
     try {
         _subject.resolve<SharedImplementationDecorator>();
-    } catch (std::runtime_error e) {
+    } catch (std::runtime_error& e) {
         exceptionThrown = true;
     }
 

--- a/type_traits.h
+++ b/type_traits.h
@@ -5,8 +5,8 @@
 #include <functional>
 #include <memory>
 #include <optional>
-#include <utility>
 #include <type_traits>
+#include <utility>
 
 namespace cdif
 {
@@ -28,13 +28,13 @@ namespace cdif
     template <typename T>
     using remove_cvref_pointer_t = typename remove_cvref_pointer<T>::type;
 
-    template <typename T, template <typename> typename C>
+    template <typename T, template <typename...> typename C>
     struct is_ptr_type
     {
-        template <typename U, template <typename> typename X>
+        template <typename U, template <typename...> typename X>
         static decltype(std::is_same<U, X<typename U::element_type>>{}) matches(std::remove_reference<U>*);
 
-        template <typename U, template <typename> typename X>
+        template <typename U, template <typename...> typename X>
         static std::false_type matches(...);
 
         using type = decltype(matches<remove_cvref_t<T>, C>(nullptr));
@@ -42,7 +42,7 @@ namespace cdif
         static constexpr bool value = { type::value };
     };
 
-    template <typename T, template <typename> typename C>
+    template <typename T, template <typename...> typename C>
     inline constexpr bool is_ptr_type_v = is_ptr_type<T, C>::value;
 
     template <typename T>


### PR DESCRIPTION
Newer compilers have started generating some warnings mostly related to copy-elision; this fixes those warnings